### PR TITLE
Fix AOT compilation issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,10 @@
 (defproject ctdean/iter
-  "0.9.0"
+  "0.9.0-SNAPSHOT"
   :description "A smart looping iterator"
   :dependencies [
                  [org.clojure/clojure "1.7.0"]
                  [medley "0.5.5"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  ]
-  :min-lein-version "2.0.0")
+  :min-lein-version "2.0.0"
+  :aot :all)

--- a/src/iter/macros.clj
+++ b/src/iter/macros.clj
@@ -17,7 +17,7 @@
 ;;; Register iter macros
 ;;;
 
-(defn- reg-macro [src dst]
+(defn reg-macro [src dst]
   (xlet [fq-dst (symbol (str (ns-name *ns*) "/" dst))]
     (swap! registered-macros
            assoc
@@ -31,8 +31,9 @@
   parsing.  The macro might be called using the plain or fully
   qualified name, so we register both names."
   [iname & args-body]
-  (reg-macro iname iname)
-  `(defmacro ~iname ~@args-body))
+  `(do
+    (reg-macro '~iname '~iname)
+    (defmacro ~iname ~@args-body)))
 
 ;; Macro versions of the builtin iter keywords.
 (define-iter-op collect [expr]          `(:collect ~expr))


### PR DESCRIPTION
Previously, iter macro registration would fail when AOT compilation was
enabled. This is because the Clojure compiler makes the very odd choice
of executing top-level forms at compile-time rather than run-time. Since
the macro registration was happening at macro-expansion time, it was
never getting initialized in AOT code.
